### PR TITLE
Dont' hide dropdown on blur event by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 - Add "Getting Started" and "Development" documents.
 - Add a contributing guide.
 
+### Changed
+- Don't hide dropdown on blur event by default.
+
 ## [0.2.0] - 2016-02-29
 ### Added
 - Enable to select dropdown in touch devices.

--- a/src/editor.js
+++ b/src/editor.js
@@ -25,10 +25,6 @@ class Editor extends EventEmitter {
    */
 
   /**
-   * @event Editor#blur
-   */
-
-  /**
    * It is called when a search result is selected by a user.
    *
    * @param {SearchResult} _searchResult

--- a/src/textarea.js
+++ b/src/textarea.js
@@ -2,7 +2,7 @@ import Editor, {ENTER, UP, DOWN} from './editor';
 
 const getCaretCoordinates = require('textarea-caret');
 
-const CALLBACK_METHODS = ['onBlur', 'onKeydown', 'onKeyup'];
+const CALLBACK_METHODS = ['onKeydown', 'onKeyup'];
 
 /**
  * Encapsulate the target textarea element.
@@ -23,7 +23,6 @@ class Textarea extends Editor {
       this[name] = this[name].bind(this);
     });
 
-    this.el.addEventListener('blur', this.onBlur);
     this.el.addEventListener('keydown', this.onKeydown);
     this.el.addEventListener('keyup', this.onKeyup);
   }
@@ -116,15 +115,6 @@ class Textarea extends Editor {
     var computed = document.defaultView.getComputedStyle(this.el);
     var lineHeight = parseInt(computed.lineHeight, 10);
     return isNaN(lineHeight) ? parseInt(computed.fontSize, 10) : lineHeight;
-  }
-
-  /**
-   * @private
-   * @fires Editor#blur
-   * @param {FocusEvent} _e
-   */
-  onBlur(_e) {
-    this.emit('blur');
   }
 
   /**

--- a/src/textcomplete.js
+++ b/src/textcomplete.js
@@ -8,7 +8,6 @@ import isFunction from 'lodash.isfunction';
 import {EventEmitter} from 'events';
 
 const CALLBACK_METHODS = [
-  'handleBlur',
   'handleChange',
   'handleHit',
   'handleMove',
@@ -150,14 +149,6 @@ class Textcomplete extends EventEmitter {
 
   /**
    * @private
-   * @listens Editor#blur
-   */
-  handleBlur() {
-    this.dropdown.deactivate();
-  }
-
-  /**
-   * @private
    * @param {SearchResult} searchResult
    * @listens Dropdown#select
    */
@@ -185,8 +176,7 @@ class Textcomplete extends EventEmitter {
    */
   startListening() {
     this.editor.on('move', this.handleMove)
-               .on('change', this.handleChange)
-               .on('blur', this.handleBlur);
+               .on('change', this.handleChange);
     this.dropdown.on('select', this.handleSelect)
                  .on('show', this.buildHandler('show'))
                  .on('shown', this.buildHandler('shown'))

--- a/test/integration/basic-spec.js
+++ b/test/integration/basic-spec.js
@@ -118,15 +118,4 @@ describe('Integration test', function () {
     assert.equal(textareaEl.selectionStart, 11);
     assert.equal(textareaEl.selectionEnd, 11);
   });
-
-  it('should work when blur', function () {
-    input(50, false, false, true, 'Hi, @'); // '@'
-    expectDropdownIsHidden();
-    input(65, false, false, false, 'Hi, @a'); // 'a'
-    expectDropdownIsShown();
-    var blurEvent = document.createEvent('UIEvents');
-    blurEvent.initEvent('blur', true, true);
-    textareaEl.dispatchEvent(blurEvent);
-    expectDropdownIsHidden();
-  });
 });


### PR DESCRIPTION
# Why

Enable developers to handle the behavior.

```js
// Hide dropdown when a blur event occurs to the editor element.
textcomplete.editor.el.addEventListener('blur', function (e) {
  textcomplete.dropdown.deactivate();
});
```