### PR TITLE
Don't activate the first dropdown item by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 ### Added
 - Add "Getting Started" and "Development" documents.
 - Add a contributing guide.
+- Add `Dropdown#el` and `Dropdown#getActiveItem()` to its public interface.
 
 ### Changed
 - Don't hide dropdown on blur event by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
 ### Changed
 - Don't hide dropdown on blur event by default.
+- Don't activate the first dropdown item by default.
 
 ## [0.2.0] - 2016-02-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 - Don't hide dropdown on blur event by default.
 - Don't activate the first dropdown item by default.
 
+### Removed
+- Remove `Dropdown#length`
+
 ## [0.2.0] - 2016-02-29
 ### Added
 - Enable to select dropdown in touch devices.

--- a/src/dropdown-item.js
+++ b/src/dropdown-item.js
@@ -63,9 +63,6 @@ class DropdownItem {
     this.dropdown = dropdown;
     this.siblings = dropdown.items;
     this.index = this.siblings.length - 1;
-    if (this.index === 0) {
-      this.activate();
-    }
   }
 
   /**

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -77,13 +77,6 @@ class Dropdown extends EventEmitter {
   }
 
   /**
-   * @returns {number}
-   */
-  get length() {
-    return this.items.length;
-  }
-
-  /**
    * Render the given data as dropdown items.
    *
    * @param {SearchResult[]} searchResults

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -261,16 +261,22 @@ class Dropdown extends EventEmitter {
 
   /**
    * @private
-   * @param {string} name
+   * @param {string} name - "next" or "prev".
    * @param {function} callback
    * @returns {this}
    */
   moveActiveItem(name, callback) {
     if (this.shown) {
       let activeItem = this.getActiveItem();
+      let nextActiveItem;
       if (activeItem) {
         activeItem.deactivate();
-        callback(activeItem[name].activate());
+        nextActiveItem = activeItem[name];
+      } else {
+        nextActiveItem = name === 'next' ? this.items[0] : this.items[this.items.length - 1];
+      }
+      if (nextActiveItem) {
+        callback(nextActiveItem.activate());
       }
     }
     return this;

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -68,8 +68,7 @@ class Dropdown extends EventEmitter {
   }
 
   /**
-   * @private
-   * @returns {HTMLUListElement}
+   * @returns {HTMLUListElement} the dropdown element.
    */
   get el() {
     this._el || (this._el = Dropdown.createElement());
@@ -152,6 +151,15 @@ class Dropdown extends EventEmitter {
    */
   down(callback) {
     return this.moveActiveItem('next', callback);
+  }
+
+  /**
+   * Retrieve the active item.
+   *
+   * @returns {DropdownItem|undefined}
+   */
+  getActiveItem() {
+    return this.items.find((item) => { return item.active; });
   }
 
   /**
@@ -240,16 +248,6 @@ class Dropdown extends EventEmitter {
     this.items.forEach((item) => { item.finalize(); });
     this.items = [];
     return this;
-  }
-
-  /**
-   * Retrieve the active item.
-   *
-   * @private
-   * @returns {DropdownItem|undefined}
-   */
-  getActiveItem() {
-    return this.items.find((item) => { return item.active; });
   }
 
   /**

--- a/src/textarea.js
+++ b/src/textarea.js
@@ -151,7 +151,8 @@ class Textarea extends Editor {
    * @returns {boolean}
    */
   isMoveKeyEvent(e) {
-    return this.getCode(e) !== null;
+    var code = this.getCode(e);
+    return code !== ENTER && code !== null;
   }
 
   /**

--- a/test/integration/basic-spec.js
+++ b/test/integration/basic-spec.js
@@ -82,6 +82,8 @@ describe('Integration test', function () {
     expectDropdownIsShown();
     input(40, false, false, false, 'Hi, @a'); // down
     expectDropdownIsShown();
+    input(40, false, false, false, 'Hi, @a'); // down
+    expectDropdownIsShown();
     input(13, false, false, false); // enter
     expectDropdownIsHidden();
     assert.equal(textareaEl.value, 'Hi, @amanda ');

--- a/test/unit/dropdown-spec.js
+++ b/test/unit/dropdown-spec.js
@@ -253,9 +253,9 @@ describe('Dropdown', function () {
     it('should empty itself', function () {
       var dropdown = new Dropdown({});
       dropdown.append([new DropdownItem(createSearchResult())]);
-      assert.equal(dropdown.length, 1);
+      assert.equal(dropdown.items.length, 1);
       dropdown.deactivate();
-      assert.equal(dropdown.length, 0);
+      assert.equal(dropdown.items.length, 0);
     });
 
     context('when it is shown', function () {

--- a/test/unit/dropdown-spec.js
+++ b/test/unit/dropdown-spec.js
@@ -1,6 +1,7 @@
 import Dropdown from '../../src/dropdown';
 import DropdownItem from '../../src/dropdown-item';
 import {createSearchResult} from '../test-helper';
+import isUndefined from 'lodash.isundefined';
 
 const assert = require('power-assert');
 
@@ -489,6 +490,41 @@ describe('Dropdown', function () {
         var spy = this.sinon.spy();
         dropdown.down(spy);
         assert(!spy.called);
+      });
+    });
+  });
+
+  describe('#getActiveItem', function () {
+    var dropdown;
+
+    beforeEach(function () {
+      dropdown = new Dropdown({});
+      dropdown.render([
+        createSearchResult(),
+        createSearchResult(),
+        createSearchResult(),
+      ], { top: 0, left: 0 });
+    });
+
+    function subject() {
+      return dropdown.getActiveItem();
+    }
+
+    context('without active item', function () {
+      it('should return undefined', function () {
+        assert(isUndefined(subject()));
+      });
+    });
+
+    context('with active item', function () {
+      var activeItem;
+
+      beforeEach(function () {
+        activeItem = dropdown.items[1].activate();
+      });
+
+      it('should return the active item', function () {
+        assert.strictEqual(subject(), activeItem);
       });
     });
   });

--- a/test/unit/dropdown-spec.js
+++ b/test/unit/dropdown-spec.js
@@ -323,7 +323,7 @@ describe('Dropdown', function () {
 
         beforeEach(function () {
           dropdown.render([createSearchResult()], { top: 0, left: 0 });
-          activeItem = dropdown.getActiveItem();
+          activeItem = dropdown.items[0].activate();
         });
 
         it('should callback with the active DropdownItem', function () {
@@ -386,9 +386,10 @@ describe('Dropdown', function () {
             createSearchResult(),
             createSearchResult(),
           ], { top: 0, left: 0 });
-          assert(dropdown.items[0].active);
+          assert(!dropdown.items[0].active);
           assert(!dropdown.items[1].active);
           assert(!dropdown.items[2].active);
+
           var spy = this.sinon.spy();
           dropdown.up(spy);
           assert(!dropdown.items[0].active);
@@ -396,6 +397,14 @@ describe('Dropdown', function () {
           assert(dropdown.items[2].active);
           assert(spy.calledOnce);
           assert(spy.calledWith(dropdown.items[2]));
+
+          spy.reset();
+          dropdown.up(spy);
+          assert(!dropdown.items[0].active);
+          assert(dropdown.items[1].active);
+          assert(!dropdown.items[2].active);
+          assert(spy.calledOnce);
+          assert(spy.calledWith(dropdown.items[1]));
         });
       });
 
@@ -440,10 +449,19 @@ describe('Dropdown', function () {
             createSearchResult(),
             createSearchResult(),
           ], { top: 0, left: 0 });
+          assert(!dropdown.items[0].active);
+          assert(!dropdown.items[1].active);
+          assert(!dropdown.items[2].active);
+
+          var spy = this.sinon.spy();
+          dropdown.down(spy);
           assert(dropdown.items[0].active);
           assert(!dropdown.items[1].active);
           assert(!dropdown.items[2].active);
-          var spy = this.sinon.spy();
+          assert(spy.calledOnce);
+          assert(spy.calledWith(dropdown.items[0]));
+
+          spy.reset();
           dropdown.down(spy);
           assert(!dropdown.items[0].active);
           assert(dropdown.items[1].active);


### PR DESCRIPTION
# Why

Enable developers to handle the behavior.

```js
// Activate the first item by default.
textcomplete.on('rendered', function () {
  if (!textcomplete.dropdown.getActiveItem() && textcomplete.dropdown.items.lenth > 0) {
    textcomplete.dropdown.items[0].activate();
  }
});
```