### PR TITLE
Add render event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 - Add "Getting Started" and "Development" documents.
 - Add a contributing guide.
 - Add `Dropdown#el` and `Dropdown#getActiveItem()` to its public interface.
+- Add `render` event to `Textcomplete`.
 
 ### Changed
 - Don't hide dropdown on blur event by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 ### Changed
 - Don't hide dropdown on blur event by default.
 - Don't activate the first dropdown item by default.
+- Emit `rendered` event whenever dropdown is rendered.
 
 ### Removed
 - Remove `Dropdown#length`

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -81,6 +81,7 @@ class Dropdown extends EventEmitter {
    * @param {SearchResult[]} searchResults
    * @param {Dropdown~Offset} cursorOffset
    * @returns {this}
+   * @fires Dropdown#rendered
    */
   render(searchResults, cursorOffset) {
     var rawResults = [], dropdownItems = [];
@@ -93,8 +94,12 @@ class Dropdown extends EventEmitter {
     this.clear()
         .renderEdge(rawResults, 'header')
         .append(dropdownItems)
-        .renderEdge(rawResults, 'footer');
-    return this.items.length > 0 ? this.setOffset(cursorOffset).show() : this.hide();
+        .renderEdge(rawResults, 'footer')
+        .setOffset(cursorOffset)
+        .show();
+    /** @event Dropdown#rendered */
+    this.emit('rendered');
+    return this;
   }
 
   /**
@@ -201,7 +206,6 @@ class Dropdown extends EventEmitter {
    * @returns {this}
    * @fires Dropdown#show
    * @fires Dropdown#shown
-   * @fires Dropdown#rendered
    */
   show() {
     if (!this.shown) {
@@ -212,8 +216,6 @@ class Dropdown extends EventEmitter {
       /** @event Dropdown#shown */
       this.emit('shown');
     }
-    /** @event Dropdown#rendered */
-    this.emit('rendered');
     return this;
   }
 

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -81,10 +81,13 @@ class Dropdown extends EventEmitter {
    * @param {SearchResult[]} searchResults
    * @param {Dropdown~Offset} cursorOffset
    * @returns {this}
+   * @fires Dropdown#render
    * @fires Dropdown#rendered
    */
   render(searchResults, cursorOffset) {
-    var rawResults = [], dropdownItems = [];
+    /** @event Dropdown#render */
+    this.emit('render');
+    let rawResults = [], dropdownItems = [];
     searchResults.forEach(searchResult => {
       rawResults.push(searchResult.data);
       if (dropdownItems.length < this.maxCount) {

--- a/src/textcomplete.js
+++ b/src/textcomplete.js
@@ -177,12 +177,10 @@ class Textcomplete extends EventEmitter {
   startListening() {
     this.editor.on('move', this.handleMove)
                .on('change', this.handleChange);
-    this.dropdown.on('select', this.handleSelect)
-                 .on('show', this.buildHandler('show'))
-                 .on('shown', this.buildHandler('shown'))
-                 .on('rendered', this.buildHandler('rendered'))
-                 .on('hide', this.buildHandler('hide'))
-                 .on('hidden', this.buildHandler('hidden'));
+    this.dropdown.on('select', this.handleSelect);
+    ['show', 'shown', 'render', 'rendered', 'hide', 'hidden'].forEach(eventName => {
+      this.dropdown.on(eventName, this.buildHandler(eventName));
+    });
     this.completer.on('hit', this.handleHit);
   }
 }

--- a/test/unit/dropdown-spec.js
+++ b/test/unit/dropdown-spec.js
@@ -58,6 +58,14 @@ describe('Dropdown', function () {
       assert.strictEqual(subject(), dropdown);
     });
 
+    it('should emit rendered event', function () {
+      var spy = this.sinon.spy();
+      dropdown = new Dropdown({});
+      dropdown.on('rendered', spy);
+      subject();
+      assert(spy.calledOnce);
+    });
+
     context('when search results are given', function () {
       it('should append dropdown items with the search results', function () {
         dropdown = new Dropdown({});
@@ -68,47 +76,33 @@ describe('Dropdown', function () {
       });
 
       context('and it has not been shown', function () {
-        it('should change #shown from false to true', function () {
+        beforeEach(function () {
           dropdown = new Dropdown({});
           dropdown.shown = false;
+        });
+
+        it('should change #shown from false to true', function () {
           subject();
           assert(dropdown.shown);
         });
 
-        ['show', 'shown', 'rendered'].forEach(eventName => {
+        ['show', 'shown'].forEach(eventName => {
           it(`should emit ${eventName} event`, function () {
             var spy = this.sinon.spy();
-            dropdown = new Dropdown({});
-            dropdown.shown = false;
             dropdown.on(eventName, spy);
             subject();
             assert(spy.calledOnce);
           });
         });
-
-        ['hide', 'hidden'].forEach(eventName => {
-          it(`should not emit ${eventName} event`, function () {
-            var spy = this.sinon.spy();
-            dropdown = new Dropdown({});
-            dropdown.shown = true;
-            dropdown.on(eventName, spy);
-            subject();
-            assert(!spy.called);
-          });
-        });
       });
 
       context('and it has been shown', function () {
-        it('should emit rendered event', function () {
-          var spy = this.sinon.spy();
+        beforeEach(function () {
           dropdown = new Dropdown({});
-          dropdown.shown = false;
-          dropdown.on('rendered', spy);
-          subject();
-          assert(spy.calledOnce);
+          dropdown.shown = true;
         });
 
-        ['show', 'shown', 'hide', 'hidden'].forEach(eventName => {
+        ['show', 'shown'].forEach(eventName => {
           it(`should not emit ${eventName} event`, function () {
             var spy = this.sinon.spy();
             dropdown = new Dropdown({});
@@ -127,29 +121,14 @@ describe('Dropdown', function () {
       }
 
       context('and it has been shown', function () {
-        it('should change #shown from true to false', function () {
+        beforeEach(function () {
           dropdown = new Dropdown({});
           dropdown.shown = true;
-          subject_();
-          assert(!dropdown.shown);
         });
 
-        ['hide', 'hidden'].forEach(eventName => {
-          it(`should emit ${eventName} event`, function () {
-            var spy = this.sinon.spy();
-            dropdown = new Dropdown({});
-            dropdown.shown = true;
-            dropdown.on(eventName, spy);
-            subject_();
-            assert(spy.calledOnce);
-          });
-        });
-
-        ['show', 'shown', 'rendered'].forEach(eventName => {
+        ['show', 'shown'].forEach(eventName => {
           it(`should not emit ${eventName} event`, function () {
             var spy = this.sinon.spy();
-            dropdown = new Dropdown({});
-            dropdown.shown = true;
             dropdown.on(eventName, spy);
             subject_();
             assert(!spy.called);
@@ -158,14 +137,17 @@ describe('Dropdown', function () {
       });
 
       context('and it has not been shown', function () {
-        ['show', 'shown', 'rendered', 'hide', 'hidden'].forEach(eventName => {
-          it(`should not emit ${eventName} event`, function () {
+        beforeEach(function () {
+          dropdown = new Dropdown({});
+          dropdown.shown = false;
+        });
+
+        ['show', 'shown'].forEach(eventName => {
+          it(`should emit ${eventName} event`, function () {
             var spy = this.sinon.spy();
-            dropdown = new Dropdown({});
-            dropdown.shown = false;
             dropdown.on(eventName, spy);
-            subject_();
-            assert(!spy.called);
+            subject();
+            assert(spy.calledOnce);
           });
         });
       });

--- a/test/unit/dropdown-spec.js
+++ b/test/unit/dropdown-spec.js
@@ -58,12 +58,14 @@ describe('Dropdown', function () {
       assert.strictEqual(subject(), dropdown);
     });
 
-    it('should emit rendered event', function () {
-      var spy = this.sinon.spy();
-      dropdown = new Dropdown({});
-      dropdown.on('rendered', spy);
-      subject();
-      assert(spy.calledOnce);
+    ['render', 'rendered'].forEach(name => {
+      it(`should emit ${name} event`, function () {
+        var spy = this.sinon.spy();
+        dropdown = new Dropdown({});
+        dropdown.on(name, spy);
+        subject();
+        assert(spy.calledOnce);
+      });
     });
 
     context('when search results are given', function () {

--- a/test/unit/textcomplete-spec.js
+++ b/test/unit/textcomplete-spec.js
@@ -69,7 +69,7 @@ describe('Textcomplete', function () {
   });
 
   describe('events', function () {
-    ['show', 'shown', 'rendered', 'hide', 'hidden'].forEach(eventName => {
+    ['show', 'shown', 'render', 'rendered', 'hide', 'hidden'].forEach(eventName => {
       context(`when Dropdown#${eventName} occurs`, function () {
         function subject() {
           textcomplete.dropdown.emit(eventName);


### PR DESCRIPTION
Closes #25 

# What

- Add "render" event to `Textcomplete`.
- Emit "rendered" event whenever `Dropdown` is rendered for better consistency.