### PR TITLE
Fix editor interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
 ### Changed
 - Use methods instead of getter properties to define `Editor` class.
+- Emit a custom event on Editor#change event.
 
 ### Fixed
 - Fix dropdown position when window is scrolled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 ## [Unreleased]
 ### Added
 - Enable to preload third party editor classes via `Textcomplete.editors`.
+- Enable to select dropdown by tab key.
 
 ### Changed
 - Use methods instead of getter properties to define `Editor` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
 ### Changed
 - Use methods instead of getter properties to define `Editor` class.
-- Emit a custom event on Editor#change event.
+- Emit a custom event on Editor#change and Editor#move event.
 
 ### Fixed
 - Fix dropdown position when window is scrolled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 ### Added
 - Enable to preload third party editor classes via `Textcomplete.editors`.
 
+### Changed
+- Use methods instead of getter properties to define `Editor` class.
+
 ### Fixed
 - Fix dropdown position when window is scrolled.
 

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -191,19 +191,19 @@ class Dropdown extends EventEmitter {
   }
 
   /**
-   * @param {function} callback
+   * @param {Editor#move} e
    * @returns {this}
    */
-  up(callback) {
-    return this.moveActiveItem('prev', callback);
+  up(e) {
+    return this.shown ? this.moveActiveItem('prev', e) : this;
   }
 
   /**
-   * @param {function} callback
+   * @param {Editor#move} e
    * @returns {this}
    */
-  down(callback) {
-    return this.moveActiveItem('next', callback);
+  down(e) {
+    return this.shown ? this.moveActiveItem('next', e) : this;
   }
 
   /**
@@ -307,22 +307,21 @@ class Dropdown extends EventEmitter {
   /**
    * @private
    * @param {string} name - "next" or "prev".
-   * @param {function} callback
+   * @param {Editor#move} e
    * @returns {this}
    */
-  moveActiveItem(name, callback) {
-    if (this.shown) {
-      let activeItem = this.getActiveItem();
-      let nextActiveItem;
-      if (activeItem) {
-        activeItem.deactivate();
-        nextActiveItem = activeItem[name];
-      } else {
-        nextActiveItem = name === 'next' ? this.items[0] : this.items[this.items.length - 1];
-      }
-      if (nextActiveItem) {
-        callback(nextActiveItem.activate());
-      }
+  moveActiveItem(name, e) {
+    let activeItem = this.getActiveItem();
+    let nextActiveItem;
+    if (activeItem) {
+      activeItem.deactivate();
+      nextActiveItem = activeItem[name];
+    } else {
+      nextActiveItem = name === 'next' ? this.items[0] : this.items[this.items.length - 1];
+    }
+    if (nextActiveItem) {
+      nextActiveItem.activate();
+      e.preventDefault();
     }
     return this;
   }

--- a/src/editor.js
+++ b/src/editor.js
@@ -8,9 +8,10 @@ export const DOWN = 2;
 
 /**
  * @event Editor#move
- * @type {object}
- * @prop {number} code
- * @prop {function} callback
+ * @type {CustomEvent}
+ * @prop {function} preventDefault
+ * @prop {object} detail
+ * @prop {number} detail.code
  */
 
 /**
@@ -72,6 +73,23 @@ class Editor extends EventEmitter {
    */
   getAfterCursor() {
     throw new Error('Not implemented.');
+  }
+
+  /**
+   * @private
+   * @fires Editor#move
+   * @param {number} code - ENTER, UP, DOWN or null.
+   * @returns {Editor#move}
+   */
+  emitMoveEvent(code) {
+    var moveEvent = createCustomEvent('move', {
+      cancelable: true,
+      detail: {
+        code: code,
+      },
+    });
+    this.emit('move', moveEvent);
+    return moveEvent;
   }
 
   /**

--- a/src/editor.js
+++ b/src/editor.js
@@ -20,6 +20,9 @@ export const DOWN = 2;
 /**
  * Abstract class representing a editor target.
  *
+ * Editor classes must implement `#applySearchResult`, `#getCursorOffset`,
+ * `#getBeforeCursor` and `#getAfterCursor` methods.
+ *
  * @abstract
  * @extends EventEmitter
  */
@@ -46,7 +49,25 @@ class Editor extends EventEmitter {
    *
    * @type {Dropdown~Offset}
    */
-  get cursorOffset() {
+  getCursorOffset() {
+    throw new Error('Not implemented.');
+  }
+
+  /**
+   * Editor string value from head to cursor.
+   *
+   * @private
+   */
+  getBeforeCursor() {
+    throw new Error('Not implemented.');
+  }
+
+  /**
+   * Editor string value from cursor to tail.
+   *
+   * @private
+   */
+  getAfterCursor() {
     throw new Error('Not implemented.');
   }
 }

--- a/src/editor.js
+++ b/src/editor.js
@@ -5,6 +5,7 @@ import {EventEmitter} from 'events';
 export const ENTER = 0;
 export const UP = 1;
 export const DOWN = 2;
+export const OTHER = 3;
 
 /**
  * @event Editor#move
@@ -78,7 +79,7 @@ class Editor extends EventEmitter {
   /**
    * @private
    * @fires Editor#move
-   * @param {number} code - ENTER, UP, DOWN or null.
+   * @param {ENTER|UP|DOWN|OTHER} code
    * @returns {Editor#move}
    */
   emitMoveEvent(code) {
@@ -105,6 +106,20 @@ class Editor extends EventEmitter {
     });
     this.emit('change', changeEvent);
     return changeEvent;
+  }
+
+  /**
+   * @private
+   * @param {KeyboardEvent} e
+   * @returns {ENTER|UP|DOWN|OTHER}
+   */
+  getCode(e) {
+    return e.keyCode === 13 ? ENTER
+         : e.keyCode === 38 ? UP
+         : e.keyCode === 40 ? DOWN
+         : e.keyCode === 78 && e.ctrlKey ? DOWN // ctrl-n
+         : e.keyCode === 80 && e.ctrlKey ? UP // ctrl-p
+         : OTHER;
   }
 }
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,3 +1,5 @@
+import {createCustomEvent} from './utils';
+
 import {EventEmitter} from 'events';
 
 export const ENTER = 0;
@@ -13,8 +15,9 @@ export const DOWN = 2;
 
 /**
  * @event Editor#change
- * @type {object}
- * @prop {string} beforeCursor
+ * @type {CustomEvent}
+ * @prop {object} detail
+ * @prop {string} detail.beforeCursor
  */
 
 /**
@@ -69,6 +72,21 @@ class Editor extends EventEmitter {
    */
   getAfterCursor() {
     throw new Error('Not implemented.');
+  }
+
+  /**
+   * @private
+   * @fires Editor#change
+   * @returns {Editor#change}
+   */
+  emitChangeEvent() {
+    var changeEvent = createCustomEvent('change', {
+      detail: {
+        beforeCursor: this.getBeforeCursor(),
+      },
+    });
+    this.emit('change', changeEvent);
+    return changeEvent;
   }
 }
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -114,9 +114,10 @@ class Editor extends EventEmitter {
    * @returns {ENTER|UP|DOWN|OTHER}
    */
   getCode(e) {
-    return e.keyCode === 13 ? ENTER
-         : e.keyCode === 38 ? UP
-         : e.keyCode === 40 ? DOWN
+    return e.keyCode === 9 ? ENTER // tab
+         : e.keyCode === 13 ? ENTER // enter
+         : e.keyCode === 38 ? UP // up
+         : e.keyCode === 40 ? DOWN // down
          : e.keyCode === 78 && e.ctrlKey ? DOWN // ctrl-n
          : e.keyCode === 80 && e.ctrlKey ? UP // ctrl-p
          : OTHER;

--- a/src/textarea.js
+++ b/src/textarea.js
@@ -39,7 +39,7 @@ class Textarea extends Editor {
    * @param {SearchResult} searchResult
    */
   applySearchResult(searchResult) {
-    var replace = searchResult.replace(this.beforeCursor, this.afterCursor);
+    var replace = searchResult.replace(this.getBeforeCursor(), this.getAfterCursor());
     if (Array.isArray(replace)) {
       this.el.value = replace[0] + replace[1];
       this.el.selectionStart = this.el.selectionEnd = replace[0].length;
@@ -47,7 +47,7 @@ class Textarea extends Editor {
     this.el.focus(); // Clicking a dropdown item removes focus from the element.
   }
 
-  get cursorOffset() {
+  getCursorOffset() {
     var elOffset = calculateElementOffset(this.el);
     var elScroll = this.getElScroll();
     var cursorPosition = this.getCursorPosition();
@@ -60,21 +60,13 @@ class Textarea extends Editor {
     }
   }
 
-  /**
-   * The string from head to current input cursor position.
-   *
-   * @private
-   * @returns {string}
-   */
-  get beforeCursor() {
+  /** @override */
+  getBeforeCursor() {
     return this.el.value.substring(0, this.el.selectionEnd);
   }
 
-  /**
-   * @private
-   * @returns {string}
-   */
-  get afterCursor() {
+  /** @override */
+  getAfterCursor() {
     return this.el.value.substring(this.el.selectionEnd);
   }
 
@@ -131,7 +123,7 @@ class Textarea extends Editor {
    */
   onKeyup(e) {
     if (!this.isMoveKeyEvent(e)) {
-      this.emit('change', { beforeCursor: this.beforeCursor });
+      this.emit('change', { beforeCursor: this.getBeforeCursor() });
     }
   }
 

--- a/src/textarea.js
+++ b/src/textarea.js
@@ -1,4 +1,4 @@
-import Editor, {ENTER, UP, DOWN} from './editor';
+import Editor, {ENTER, OTHER} from './editor';
 import {calculateElementOffset} from './utils';
 
 import bindAll from 'lodash.bindall';
@@ -106,7 +106,7 @@ class Textarea extends Editor {
    */
   onKeydown(e) {
     var code = this.getCode(e);
-    if (code === null) { return; }
+    if (code === OTHER) { return; }
     var moveEvent = this.emitMoveEvent(code);
     if (moveEvent.defaultPrevented) {
       e.preventDefault();
@@ -131,21 +131,7 @@ class Textarea extends Editor {
    */
   isMoveKeyEvent(e) {
     var code = this.getCode(e);
-    return code !== ENTER && code !== null;
-  }
-
-  /**
-   * @private
-   * @param {KeyboardEvent} e
-   * @returns {ENTER|UP|DOWN|null}
-   */
-  getCode(e) {
-    return e.keyCode === 13 ? ENTER
-         : e.keyCode === 38 ? UP
-         : e.keyCode === 40 ? DOWN
-         : e.keyCode === 78 && e.ctrlKey ? DOWN
-         : e.keyCode === 80 && e.ctrlKey ? UP
-         : null;
+    return code !== ENTER && code !== OTHER;
   }
 
   /**

--- a/src/textarea.js
+++ b/src/textarea.js
@@ -106,13 +106,10 @@ class Textarea extends Editor {
    */
   onKeydown(e) {
     var code = this.getCode(e);
-    if (code !== null) {
-      this.emit('move', {
-        code: code,
-        callback: function () {
-          e.preventDefault();
-        },
-      });
+    if (code === null) { return; }
+    var moveEvent = this.emitMoveEvent(code);
+    if (moveEvent.defaultPrevented) {
+      e.preventDefault();
     }
   }
 

--- a/src/textarea.js
+++ b/src/textarea.js
@@ -123,7 +123,7 @@ class Textarea extends Editor {
    */
   onKeyup(e) {
     if (!this.isMoveKeyEvent(e)) {
-      this.emit('change', { beforeCursor: this.getBeforeCursor() });
+      this.emitChangeEvent();
     }
   }
 

--- a/src/textcomplete.js
+++ b/src/textcomplete.js
@@ -164,11 +164,11 @@ class Textcomplete extends EventEmitter {
 
   /**
    * @private
-   * @param {string} beforeCursor
+   * @param {Editor#change} e
    * @listens Editor#change
    */
-  handleChange({beforeCursor}) {
-    this.trigger(beforeCursor);
+  handleChange(e) {
+    this.trigger(e.detail.beforeCursor);
   }
 
   /**

--- a/src/textcomplete.js
+++ b/src/textcomplete.js
@@ -137,26 +137,25 @@ class Textcomplete extends EventEmitter {
 
   /**
    * @private
-   * @param {ENTER|UP|DOWN} code
-   * @param {funcion} callback
+   * @param {Editor#move} e
    * @listens Editor#move
    */
-  handleMove({code, callback}) {
-    switch (code) {
+  handleMove(e) {
+    switch (e.detail.code) {
       case ENTER: {
         let activeItem = this.dropdown.getActiveItem();
         if (activeItem) {
           this.dropdown.select(activeItem);
-          callback(activeItem);
+          e.preventDefault();
         }
         break;
       }
       case UP: {
-        this.dropdown.up(callback);
+        this.dropdown.up(e);
         break;
       }
       case DOWN: {
-        this.dropdown.down(callback);
+        this.dropdown.down(e);
         break;
       }
     }

--- a/src/textcomplete.js
+++ b/src/textcomplete.js
@@ -128,7 +128,7 @@ class Textcomplete extends EventEmitter {
    */
   handleHit({searchResults}) {
     if (searchResults.length) {
-      this.dropdown.render(searchResults, this.editor.cursorOffset);
+      this.dropdown.render(searchResults, this.editor.getCursorOffset());
     } else {
       this.dropdown.deactivate();
     }

--- a/test/unit/dropdown-spec.js
+++ b/test/unit/dropdown-spec.js
@@ -376,7 +376,7 @@ describe('Dropdown', function () {
       });
 
       context('and it contains DropdownItems', function () {
-        it('should activate the previous DropdownItem and callback it', function () {
+        it('should activate the previous DropdownItem and prevent default', function () {
           dropdown.render([
             createSearchResult(),
             createSearchResult(),
@@ -387,27 +387,25 @@ describe('Dropdown', function () {
           assert(!dropdown.items[2].active);
 
           var spy = this.sinon.spy();
-          dropdown.up(spy);
+          dropdown.up({ preventDefault: spy });
           assert(!dropdown.items[0].active);
           assert(!dropdown.items[1].active);
           assert(dropdown.items[2].active);
           assert(spy.calledOnce);
-          assert(spy.calledWith(dropdown.items[2]));
 
           spy.reset();
-          dropdown.up(spy);
+          dropdown.up({ preventDefault: spy });
           assert(!dropdown.items[0].active);
           assert(dropdown.items[1].active);
           assert(!dropdown.items[2].active);
           assert(spy.calledOnce);
-          assert(spy.calledWith(dropdown.items[1]));
         });
       });
 
       context('and it does not contain a DropdownItem', function () {
-        it('should not callback', function () {
+        it('should not prevent default', function () {
           var spy = this.sinon.spy();
-          dropdown.up(spy);
+          dropdown.up({ preventDefault: spy });
           assert(!spy.called);
         });
       });
@@ -418,9 +416,9 @@ describe('Dropdown', function () {
         dropdown.hide();
       });
 
-      it('should not callback', function () {
+      it('should not prevent default', function () {
         var spy = this.sinon.spy();
-        dropdown.up(spy);
+        dropdown.up({ preventDefault: spy });
         assert(!spy.called);
       });
     });
@@ -450,27 +448,25 @@ describe('Dropdown', function () {
           assert(!dropdown.items[2].active);
 
           var spy = this.sinon.spy();
-          dropdown.down(spy);
+          dropdown.down({ preventDefault: spy });
           assert(dropdown.items[0].active);
           assert(!dropdown.items[1].active);
           assert(!dropdown.items[2].active);
           assert(spy.calledOnce);
-          assert(spy.calledWith(dropdown.items[0]));
 
           spy.reset();
-          dropdown.down(spy);
+          dropdown.down({ preventDefault: spy });
           assert(!dropdown.items[0].active);
           assert(dropdown.items[1].active);
           assert(!dropdown.items[2].active);
           assert(spy.calledOnce);
-          assert(spy.calledWith(dropdown.items[1]));
         });
       });
 
       context('and it does not contain a DropdownItem', function () {
-        it('should not callback', function () {
+        it('should not prevent default', function () {
           var spy = this.sinon.spy();
-          dropdown.down(spy);
+          dropdown.down({ preventDefault: spy });
           assert(!spy.called);
         });
       });
@@ -483,7 +479,7 @@ describe('Dropdown', function () {
 
       it('should not callback', function () {
         var spy = this.sinon.spy();
-        dropdown.down(spy);
+        dropdown.down({ preventDefault: spy });
         assert(!spy.called);
       });
     });

--- a/test/unit/editor-spec.js
+++ b/test/unit/editor-spec.js
@@ -21,9 +21,11 @@ describe('Editor', function () {
     });
   });
 
-  describe('#cursorOffset', function () {
-    it('should throw an error', function () {
-      assert.throws(function () { editor.cursorOffset; });
+  ['getCursorOffset', 'getBeforeCursor', 'getAfterCursor'].forEach(name => {
+    describe(`#${name}`, function () {
+      it('should throw an error', function () {
+        assert.throws(function () { editor[name](); });
+      });
     });
   });
 });

--- a/test/unit/textarea-spec.js
+++ b/test/unit/textarea-spec.js
@@ -24,6 +24,7 @@ describe('Textarea', function () {
     });
 
     [
+      [9, ENTER, false],
       [13, ENTER, false],
       [38, UP, false],
       [40, DOWN, false],

--- a/test/unit/textarea-spec.js
+++ b/test/unit/textarea-spec.js
@@ -90,13 +90,13 @@ describe('Textarea', function () {
         textarea.on('change', spy);
         subject();
         assert(spy.calledOnce);
-        assert(spy.calledWith({ beforeCursor: '' }));
+        assert(spy.calledWith({ detail: { beforeCursor: '' } }));
 
         spy.reset();
         textarea.el.selectionStart = textarea.el.selectionEnd = 3;
         subject();
         assert(spy.calledOnce);
-        assert(spy.calledWith({ beforeCursor: 'abc' }));
+        assert(spy.calledWith({ detail: { beforeCursor: 'abc' } }));
       });
     });
   });

--- a/test/unit/textarea-spec.js
+++ b/test/unit/textarea-spec.js
@@ -34,7 +34,7 @@ describe('Textarea', function () {
           textarea.on('move', spy);
           subject();
           assert(spy.calledOnce);
-          assert(spy.calledWith({ code: code, callback: this.sinon.match.func }));
+          assert(spy.calledWith({ detail: { code: code } }));
         });
       });
     });

--- a/test/unit/textarea-spec.js
+++ b/test/unit/textarea-spec.js
@@ -152,7 +152,7 @@ describe('Textarea', function () {
     });
   });
 
-  describe('#cursorOffset', function () {
+  describe('#getCursorOffset', function () {
     var textareaEl;
 
     beforeEach(function () {
@@ -160,7 +160,7 @@ describe('Textarea', function () {
     });
 
     function subject() {
-      return textarea.cursorOffset;
+      return textarea.getCursorOffset();
     }
 
     context('when dir attribute of the element is "ltr"', function () {

--- a/test/unit/textarea-spec.js
+++ b/test/unit/textarea-spec.js
@@ -23,13 +23,20 @@ describe('Textarea', function () {
       event.initEvent('keydown', true, true);
     });
 
-    [ENTER, DOWN, UP].forEach(function (code) {
-      context(`and it is a ${code} key`, function () {
+    [
+      [13, ENTER, false],
+      [38, UP, false],
+      [40, DOWN, false],
+      [78, DOWN, true],
+      [80, UP, true],
+    ].forEach(([keyCode, code, ctrlKey]) => {
+      context(`and it is a ${keyCode} key`, function () {
         beforeEach(function () {
-          this.sinon.stub(textarea, 'getCode', () => { return code; });
+          event.keyCode = keyCode;
+          event.ctrlKey = ctrlKey;
         });
 
-        it('should emit a move event', function () {
+        it(`should emit a ${code} move event`, function () {
           var spy = this.sinon.spy();
           textarea.on('move', spy);
           subject();
@@ -41,7 +48,7 @@ describe('Textarea', function () {
 
     context('and it is a normal key', function () {
       beforeEach(function () {
-        this.sinon.stub(textarea, 'getCode', () => { return null; });
+        event.keyCode = 65;
       });
 
       it('should not emit a move event', function () {

--- a/test/unit/textcomplete-spec.js
+++ b/test/unit/textcomplete-spec.js
@@ -76,7 +76,7 @@ describe('Textcomplete', function () {
 
     it('should listen Editor#change', function () {
       var stub = this.sinon.stub(textcomplete, 'trigger');
-      editor.emit('change', { beforeCursor: '' });
+      editor.emit('change', { detail: { beforeCursor: '' } });
       assert(stub.calledOnce);
     });
 


### PR DESCRIPTION
### Added
- Enable to select dropdown by tab key.

### Changed
- Use methods instead of getter properties to define `Editor` class.
- Emit a custom event on Editor#change and Editor#move event.