### PR TITLE
Make demo page possible to run on Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 ## [Unreleased]
 ### Fixed
 - Update `gh-pages` automatically when actually `master` branch is changed.
+- Make demo page possible to run on Firefox.
 
 ## [0.5.0] - 2016-03-14
 ### Changed

--- a/src/doc/main.js
+++ b/src/doc/main.js
@@ -11,7 +11,7 @@ function initializeTextcompletes() {
   let els = document.getElementsByClassName('auto-eval');
   for (let i = 0, l = els.length; i < l; i++) {
     let el = els[i];
-    eval(`(function () {${el.innerText}})()`);
+    eval(`(function () {${el.innerText || el.textContent}})()`);
   }
 }
 


### PR DESCRIPTION
Closes #43 

Firefox does not support `el.innerText` :weary: 