### PR TITLE
Use input event instead of keyup event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- Use input event instead of keyup event.
+
 ### Fixed
 - Fix a bug that a typeerror occurs on every normal keydown events.
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "isparta": "^4.0.0",
     "jsdoc": "^3.4.0",
     "jsdom": "^8.0.2",
+    "keysim": "git://github.com/yuku-t/keysim.js.git#input-event",
     "lodash.isnumber": "^3.0.3",
     "lodash.isundefined": "^3.0.1",
     "postcss-cssnext": "^2.4.0",

--- a/src/doc/main.js
+++ b/src/doc/main.js
@@ -19,7 +19,7 @@ function runDemo() {
   ['textarea1', 'textarea2', 'textarea3'].forEach(id => {
     let textarea = document.getElementById(id);
     textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
-    let event = new Event('keyup', {
+    let event = new Event('input', {
       bubbles: true,
       cancelable: true,
     });

--- a/src/editor.js
+++ b/src/editor.js
@@ -6,7 +6,7 @@ export const ENTER = 0;
 export const UP = 1;
 export const DOWN = 2;
 export const OTHER = 3;
-export const META = 4;
+export const BS = 4;
 
 /**
  * @event Editor#move
@@ -129,19 +129,16 @@ class Editor extends EventEmitter {
   /**
    * @private
    * @param {KeyboardEvent} e
-   * @returns {ENTER|UP|DOWN|OTHER}
+   * @returns {ENTER|UP|DOWN|OTHER|BS}
    */
   getCode(e) {
-    return e.keyCode === 9 ? ENTER // tab
+    return e.keyCode === 8 ? BS // backspace
+         : e.keyCode === 9 ? ENTER // tab
          : e.keyCode === 13 ? ENTER // enter
-         : e.keyCode === 16 ? META // shift
-         : e.keyCode === 17 ? META // ctrl
-         : e.keyCode === 18 ? META // alt
          : e.keyCode === 38 ? UP // up
          : e.keyCode === 40 ? DOWN // down
          : e.keyCode === 78 && e.ctrlKey ? DOWN // ctrl-n
          : e.keyCode === 80 && e.ctrlKey ? UP // ctrl-p
-         : e.keyCode === 91 ? META // command
          : OTHER;
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -103,3 +103,11 @@ export function calculateElementOffset(el) {
     left: rect.left + defaultView.pageXOffset - documentElement.clientLeft,
   };
 }
+
+/**
+ * @returns {?number} Returns IE version or if not IE return null.
+ */
+export function isIE() {
+  const nav = navigator.userAgent.toLowerCase();
+  return (nav.indexOf('msie') !== -1) ? parseInt(nav.split('msie')[1], 10) : null;
+}

--- a/test/integration/basic_spec.js
+++ b/test/integration/basic_spec.js
@@ -1,7 +1,10 @@
 import Textcomplete from '../../src/textcomplete';
 import Textarea from '../../src/textarea';
 
+import Keysim from 'keysim';
+
 const assert = require('power-assert');
+const keyboard = Keysim.Keyboard.US_ENGLISH;
 
 describe('Integration test', function () {
   var textareaEl, textarea, textcomplete;
@@ -25,33 +28,6 @@ describe('Integration test', function () {
     ]);
   });
 
-  /**
-   * Emulate inputing a char to the textarea element.
-   *
-   * @param {number} keyCode
-   * @param {boolean} altKey
-   * @param {boolean} ctrlKey
-   * @param {boolean} shiftKey
-   * @param {string} value
-   * @param {?number} position
-   */
-  function input(keyCode, altKey, ctrlKey, shiftKey, value, position) {
-    var keydownEvent = document.createEvent('UIEvents');
-    var keyupEvent = document.createEvent('UIEvents');
-    keydownEvent.initEvent('keydown', true, true);
-    keyupEvent.initEvent('keyup', true, true);
-    keyupEvent.keyCode = keydownEvent.keyCode = keyCode;
-    keyupEvent.altKey = keydownEvent.altKey = altKey;
-    keyupEvent.ctrlKey = keydownEvent.ctrlKey = ctrlKey;
-    keyupEvent.shiftKey = keydownEvent.shiftKey = shiftKey;
-    textareaEl.dispatchEvent(keydownEvent);
-    if (value) {
-      textareaEl.value = value;
-      textareaEl.selectionStart = textareaEl.selectionEnd = position || value.length;
-    }
-    textareaEl.dispatchEvent(keyupEvent);
-  }
-
   function expectDropdownIsShown() {
     var dropdownEl = document.querySelector('.dropdown-menu.textcomplete-dropdown');
     var computed = window.getComputedStyle(dropdownEl);
@@ -65,36 +41,64 @@ describe('Integration test', function () {
   }
 
   it('should work with keyboard', function () {
-    input(50, false, false, true, 'Hi, @'); // '@'
+    textareaEl.value = 'Hi, @';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 5;
+    keyboard.dispatchEventsForInput('Hi, @', textareaEl);
     expectDropdownIsHidden();
-    input(65, false, false, false, 'Hi, @a'); // 'a'
+
+    textareaEl.value = 'Hi, @a';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 6;
+    keyboard.dispatchEventsForInput('a', textareaEl);
     expectDropdownIsShown();
-    input(66, false, false, false, 'Hi, @ab'); // 'b'
+
+    textareaEl.value = 'Hi, @ab';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 7;
+    keyboard.dispatchEventsForInput('b', textareaEl);
     expectDropdownIsHidden();
-    input(8, false, false, false, 'Hi, @a'); // backspace
+
+    textareaEl.value = 'Hi, @a';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 6;
+    keyboard.dispatchEventsForAction('backspace', textareaEl);
     expectDropdownIsShown();
-    input(76, false, false, false, 'Hi, @al'); // 'l'
+
+    textareaEl.value = 'Hi, @al';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 7;
+    keyboard.dispatchEventsForInput('l', textareaEl);
     expectDropdownIsShown();
-    input(8, false, false, false, 'Hi, @a'); // backspace
+
+    textareaEl.value = 'Hi, @a';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 6;
+    keyboard.dispatchEventsForAction('backspace', textareaEl);
     expectDropdownIsShown();
-    input(40, false, false, false, 'Hi, @a'); // down
+
+    keyboard.dispatchEventsForAction('down', textareaEl);
     expectDropdownIsShown();
-    input(38, false, false, false, 'Hi, @a'); // up
+
+    keyboard.dispatchEventsForAction('up', textareaEl);
     expectDropdownIsShown();
-    input(40, false, false, false, 'Hi, @a'); // down
+
+    keyboard.dispatchEventsForAction('down', textareaEl);
     expectDropdownIsShown();
-    input(13, false, false, false); // enter
+
+    keyboard.dispatchEventsForAction('enter', textareaEl);
     expectDropdownIsHidden();
+
     assert.equal(textareaEl.value, 'Hi, @alice ');
     assert.equal(textareaEl.selectionStart, 11);
     assert.equal(textareaEl.selectionEnd, 11);
   });
 
   it('should work with touch event', function () {
-    input(50, false, false, true, 'Hi, @'); // '@'
+    textareaEl.value = 'Hi, @';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 5;
+    keyboard.dispatchEventsForInput('Hi, @', textareaEl);
     expectDropdownIsHidden();
-    input(65, false, false, false, 'Hi, @a'); // 'a'
+
+    textareaEl.value = 'Hi, @a';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 6;
+    keyboard.dispatchEventsForInput('a', textareaEl);
     expectDropdownIsShown();
+
     var dropdownItemEl = document.querySelector('.textcomplete-item');
     var clickEvent = document.createEvent('TouchEvent');
     clickEvent.initEvent('touchstart', true, true);
@@ -106,10 +110,16 @@ describe('Integration test', function () {
   });
 
   it('should work with mousedown event', function () {
-    input(50, false, false, true, 'Hi, @'); // '@'
+    textareaEl.value = 'Hi, @';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 5;
+    keyboard.dispatchEventsForInput('Hi, @', textareaEl);
     expectDropdownIsHidden();
-    input(65, false, false, false, 'Hi, @a'); // 'a'
+
+    textareaEl.value = 'Hi, @a';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 6;
+    keyboard.dispatchEventsForInput('a', textareaEl);
     expectDropdownIsShown();
+
     var dropdownItemEl = document.querySelector('.textcomplete-item');
     var clickEvent = document.createEvent('MouseEvent');
     clickEvent.initEvent('mousedown', true, true);
@@ -121,10 +131,16 @@ describe('Integration test', function () {
   });
 
   it('should work with mouseover event', function () {
-    input(50, false, false, true, 'Hi, @'); // '@'
+    textareaEl.value = 'Hi, @';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 5;
+    keyboard.dispatchEventsForInput('Hi, @', textareaEl);
     expectDropdownIsHidden();
-    input(65, false, false, false, 'Hi, @a'); // 'a'
+
+    textareaEl.value = 'Hi, @a';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 6;
+    keyboard.dispatchEventsForInput('a', textareaEl);
     expectDropdownIsShown();
+
     var dropdownItemEl = document.querySelector('.textcomplete-item:last-child');
     var mouseEvent = document.createEvent('MouseEvent');
     mouseEvent.initEvent('mouseover', true, true);

--- a/test/integration/dropdown_option_spec.js
+++ b/test/integration/dropdown_option_spec.js
@@ -2,7 +2,10 @@ import Textcomplete from '../../src/textcomplete';
 import Textarea from '../../src/textarea';
 import {CLASS_NAME} from '../../src/dropdown_item';
 
+import Keysim from 'keysim';
+
 const assert = require('power-assert');
+const keyboard = Keysim.Keyboard.US_ENGLISH;
 
 describe('Dropdown options integration test', function () {
   var textareaEl, textarea;
@@ -32,11 +35,10 @@ describe('Dropdown options integration test', function () {
           return `$1@${username} `;
         },
       });
+
       textareaEl.value = '@a';
-      var keyupEvent = document.createEvent('UIEvents');
-      keyupEvent.initEvent('keyup', true, true);
-      keyupEvent.keyCode = 50;
-      textareaEl.dispatchEvent(keyupEvent);
+      textareaEl.selectionStart = textareaEl.selectionEnd = 2;
+      keyboard.dispatchEventsForInput('@a', textareaEl);
 
       var dropdownEl = document.getElementsByClassName(className);
       assert.equal(dropdownEl.length, 1);
@@ -55,11 +57,10 @@ describe('Dropdown options integration test', function () {
           return `$1@${username} `;
         },
       });
+
       textareaEl.value = '@a';
-      var keyupEvent = document.createEvent('UIEvents');
-      keyupEvent.initEvent('keyup', true, true);
-      keyupEvent.keyCode = 50;
-      textareaEl.dispatchEvent(keyupEvent);
+      textareaEl.selectionStart = textareaEl.selectionEnd = 2;
+      keyboard.dispatchEventsForInput('@a', textareaEl);
 
       var dropdownEl = document.getElementsByClassName('textcomplete-dropdown')[0];
       assert.equal(dropdownEl.style.backgroundColor, 'rgb(255, 0, 255)');
@@ -77,10 +78,7 @@ describe('Dropdown options integration test', function () {
 
       textareaEl.value = '@a';
       textareaEl.selectionStart = textareaEl.selectionEnd = 2;
-      var keyupEvent = document.createEvent('UIEvents');
-      keyupEvent.initEvent('keyup', true, true);
-      keyupEvent.keyCode = 50;
-      textareaEl.dispatchEvent(keyupEvent);
+      keyboard.dispatchEventsForInput('@a', textareaEl);
 
       var items = document.getElementsByClassName(CLASS_NAME);
       assert.equal(items.length, maxCount);
@@ -100,22 +98,13 @@ describe('Dropdown options integration test', function () {
 
         textareaEl.value = '@a';
         textareaEl.selectionStart = textareaEl.selectionEnd = 2;
-        var keyupEvent = document.createEvent('UIEvents');
-        keyupEvent.initEvent('keyup', true, true);
-        keyupEvent.keyCode = 50;
-        textareaEl.dispatchEvent(keyupEvent);
+        keyboard.dispatchEventsForInput('@a', textareaEl);
       });
 
       it('should not rotate on up key', function () {
         // Activate the first dropdown item.
         var firstItem = textcomplete.dropdown.items[0].activate();
-
-        // Press up key
-        var keydownEvent = document.createEvent('UIEvents');
-        keydownEvent.initEvent('keydown', true, true);
-        keydownEvent.keyCode = 38;
-        textareaEl.dispatchEvent(keydownEvent);
-
+        keyboard.dispatchEventsForAction('up', textareaEl);
         assert(firstItem.active);
       });
 
@@ -123,13 +112,7 @@ describe('Dropdown options integration test', function () {
         // Activate the last dropdown item.
         var dropdownItems = textcomplete.dropdown.items;
         var lastItem = dropdownItems[dropdownItems.length - 1].activate();
-
-        // Press down key
-        var keydownEvent = document.createEvent('UIEvents');
-        keydownEvent.initEvent('keydown', true, true);
-        keydownEvent.keyCode = 40;
-        textareaEl.dispatchEvent(keydownEvent);
-
+        keyboard.dispatchEventsForAction('down', textareaEl);
         assert(lastItem.active);
       });
     });

--- a/test/integration/events_spec.js
+++ b/test/integration/events_spec.js
@@ -1,7 +1,10 @@
 import Textcomplete from '../../src/textcomplete';
 import Textarea from '../../src/textarea';
 
+import Keysim from 'keysim';
+
 const assert = require('power-assert');
+const keyboard = Keysim.Keyboard.US_ENGLISH;
 
 describe('Textcomplete events', function () {
   var textareaEl, textarea, textcomplete;
@@ -22,23 +25,6 @@ describe('Textcomplete events', function () {
       },
     }]);
   });
-
-  function input(keyCode, altKey, ctrlKey, shiftKey, value, position) {
-    var keydownEvent = document.createEvent('UIEvents');
-    var keyupEvent = document.createEvent('UIEvents');
-    keydownEvent.initEvent('keydown', true, true);
-    keyupEvent.initEvent('keyup', true, true);
-    keyupEvent.keyCode = keydownEvent.keyCode = keyCode;
-    keyupEvent.altKey = keydownEvent.altKey = altKey;
-    keyupEvent.ctrlKey = keydownEvent.ctrlKey = ctrlKey;
-    keyupEvent.shiftKey = keydownEvent.shiftKey = shiftKey;
-    textareaEl.dispatchEvent(keydownEvent);
-    if (value) {
-      textareaEl.value = value;
-      textareaEl.selectionStart = textareaEl.selectionEnd = position || value.length;
-    }
-    textareaEl.dispatchEvent(keyupEvent);
-  }
 
   function assertCalled(spy) {
     assert(spy.calledOnce);
@@ -65,26 +51,36 @@ describe('Textcomplete events', function () {
       [showSpy, shownSpy, renderedSpy, hideSpy, hiddenSpy].forEach(spy => spy.reset());
     }
 
-    input(50, false, false, true, 'Hi, @'); // '@'
+    textareaEl.value = 'Hi, @';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 5;
+    keyboard.dispatchEventsForInput('Hi, @', textareaEl);
     [showSpy, shownSpy, renderedSpy, hideSpy, hiddenSpy].forEach(assertNotCalled);
     reset();
 
-    input(65, false, false, false, 'Hi, @a'); // 'a'
+    textareaEl.value = 'Hi, @a';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 6;
+    keyboard.dispatchEventsForInput('a', textareaEl);
     [showSpy, shownSpy, renderedSpy].forEach(assertCalled);
     [hideSpy, hiddenSpy].forEach(assertNotCalled);
     reset();
 
-    input(66, false, false, false, 'Hi, @ab'); // 'b'
+    textareaEl.value = 'Hi, @ab';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 7;
+    keyboard.dispatchEventsForInput('b', textareaEl);
     [renderedSpy].forEach(assertCalled);
     [showSpy, shownSpy, hideSpy, hiddenSpy].forEach(assertNotCalled);
     reset();
 
-    input(8, false, false, false, 'Hi, @a'); // backspace
+    textareaEl.value = 'Hi, @a';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 6;
+    keyboard.dispatchEventsForAction('backspace', textareaEl);
     [renderedSpy].forEach(assertCalled);
     [showSpy, shownSpy, hideSpy, hiddenSpy].forEach(assertNotCalled);
     reset();
 
-    input(8, false, false, false, 'Hi, @'); // backspace
+    textareaEl.value = 'Hi, @';
+    textareaEl.selectionStart = textareaEl.selectionEnd = 5;
+    keyboard.dispatchEventsForAction('backspace', textareaEl);
     [hideSpy, hiddenSpy].forEach(assertCalled);
     [showSpy, shownSpy, renderedSpy].forEach(assertNotCalled);
     reset();

--- a/test/test_runner.js
+++ b/test/test_runner.js
@@ -12,6 +12,7 @@ beforeEach(function () {
   this.sinon = sinon.sandbox.create();
   global.document = jsdom.jsdom();
   global.window = document.defaultView;
+  global.navigator = window.navigator; // required by isIE
   global.getComputedStyle = window.getComputedStyle; // reqiured by textarea-caret
 });
 


### PR DESCRIPTION
Closes #60

Temporarily using [patched keysim.js](https://github.com/yuku-t/keysim.js/tree/input-event) to fire input events as expected.