### PR TITLE
Fix `yarn test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:lib": "babel src -d lib -s",
     "clean": "rm -fr dist lib",
     "gh-release": "yarn pack textcomplete && gh-release -a textcomplete-$(cat package.json|jq -r .version).tgz",
-    "prepare": "git tag v$(jq -r .version package.json) && yarn run build",
+    "prepare": "git tag v$(jq -r .version package.json); yarn run build",
     "test": "run-p test:*",
     "test:e2e": "karma start --single-run",
     "test:lint": "eslint src/*.js test/**/*.js",


### PR DESCRIPTION
Previously, yarn test failed because `prepare` expected the version tag to not exist.