### PR TITLE
Remove line-height dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
   },
   "dependencies": {
     "events": "^1.1.0",
-    "line-height": "^0.1.1",
     "textarea-caret": "^3.0.1"
   },
   "babel": {

--- a/src/textarea.js
+++ b/src/textarea.js
@@ -1,10 +1,8 @@
 // @flow
 
 import Editor from './editor';
-import {calculateElementOffset} from './utils';
+import {calculateElementOffset, getLineHeightPx} from './utils';
 import SearchResult from './search_result';
-
-import getLineHeight from 'line-height';
 
 const getCaretCoordinates = require('textarea-caret');
 
@@ -59,7 +57,7 @@ export default class Textarea extends Editor {
     const elOffset = calculateElementOffset(this.el);
     const elScroll = this.getElScroll();
     const cursorPosition = this.getCursorPosition();
-    const lineHeight = getLineHeight(this.el);
+    const lineHeight = getLineHeightPx(this.el);
     const top = elOffset.top - elScroll.top + cursorPosition.top + lineHeight;
     const left = elOffset.left - elScroll.left + cursorPosition.left;
     if (this.el.dir !== 'rtl') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,6 @@ component-inherit@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
 
-computed-style@~0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/computed-style/-/computed-style-0.1.4.tgz#7f344fd8584b2e425bedca4a1afc0e300bb05d74"
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -3100,12 +3096,6 @@ liftoff@^2.2.0:
     lodash.mapvalues "^4.4.0"
     rechoir "^0.6.2"
     resolve "^1.1.7"
-
-line-height@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/line-height/-/line-height-0.1.1.tgz#e86705fbf0a6f50607aed65500d69db2d9db37e2"
-  dependencies:
-    computed-style "~0.1.3"
 
 line-reader@^0.2.4:
   version "0.2.4"


### PR DESCRIPTION
The [line-height package](https://github.com/twolfson/line-height) contains a lot of code to support browsers all the way to IE6.

As we only support IE10+, it can be replaced by a simple light-weight utility function.