### PR TITLE
Do not use `delete`

### DIFF
--- a/src/textarea.js
+++ b/src/textarea.js
@@ -38,7 +38,8 @@ export default class Textarea extends Editor {
   finalize() {
     super.finalize();
     this.stopListening();
-    delete this.el;
+    // Release the element reference early to help garbage collection.
+    (this: any).el = null;
     return this;
   }
 


### PR DESCRIPTION
Delete results in de-optimization because the browser has to revert to representing the object as a hash table of properties instead of a struct with known properties.

Use `this.el = null` instead.

Benchmark: https://jsperf.com/delete-vs-undefined-vs-null/6
V8 engineer comment: https://groups.google.com/forum/#!topic/v8-users/zE4cOHBkAnY

This has no performance impact in this case but is generally a best practice.