### PR TITLE
Remove utilities.lock

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,62 +1,6 @@
 // @flow
 
 /**
- * Exclusive execution control utility.
- *
- * @param {function} func - The function to be locked. It is executed with a
- *                          function named `free` as the first argument. Once
- *                          it is called, additional execution are ignored
- *                          until the free is invoked. Then the last ignored
- *                          execution will be replayed immediately.
- * @example
- * var lockedFunc = lock(function (free) {
- *   setTimeout(function { free(); }, 1000); // It will be free in 1 sec.
- *   console.log('Hello, world');
- * });
- * lockedFunc();  // => 'Hello, world'
- * lockedFunc();  // none
- * lockedFunc();  // none
- * // 1 sec past then
- * // => 'Hello, world'
- * lockedFunc();  // => 'Hello, world'
- * lockedFunc();  // none
- */
-export function lock(func: (Function, any) => any): Function {
-  let locked: boolean, queuedArgsToReplay: any;
-
-  return function () {
-    // Convert arguments into a real array.
-    const args = Array.prototype.slice.call(arguments);
-    if (locked) {
-      // Keep a copy of this argument list to replay later.
-      // OK to overwrite a previous value because we only replay
-      // the last one.
-      queuedArgsToReplay = args;
-      return;
-    }
-    locked = true;
-    const self = this;
-    function replayOrFree() {
-      if (queuedArgsToReplay) {
-        // Other request(s) arrived while we were locked.
-        // Now that the lock is becoming available, replay
-        // the latest such request, then call back here to
-        // unlock (or replay another request that arrived
-        // while this one was in flight).
-        const replayArgs = queuedArgsToReplay;
-        queuedArgsToReplay = undefined;
-        replayArgs.unshift(replayOrFree);
-        func.apply(self, replayArgs);
-      } else {
-        locked = false;
-      }
-    }
-    args.unshift(replayOrFree);
-    func.apply(this, args);
-  };
-}
-
-/**
  * Create a custom event
  */
 export const createCustomEvent = (() => {

--- a/test/unit/textcomplete_spec.js
+++ b/test/unit/textcomplete_spec.js
@@ -82,7 +82,7 @@ describe('Textcomplete', function () {
       assert(stub.calledOnce);
     });
 
-    it('should call #completer.run exclusvely', function () {
+    it('should call #completer.run exclusively', function () {
       var stub = this.sinon.stub(textcomplete.completer, 'run');
 
       textcomplete.trigger('a');
@@ -90,11 +90,12 @@ describe('Textcomplete', function () {
       assert(stub.calledOnce);
       assert(stub.calledWith('a'));
 
-      textcomplete.unlock();
+      textcomplete.handleHit({searchResults: []});
       assert(stub.calledTwice); // Replay
       assert(stub.calledWith('b'));
 
-      textcomplete.unlock().trigger('c');
+      textcomplete.handleHit({searchResults: []});
+      textcomplete.trigger('c');
       assert(stub.calledThrice);
       assert(stub.calledWith('c'));
 

--- a/test/unit/utils_spec.js
+++ b/test/unit/utils_spec.js
@@ -1,46 +1,8 @@
 require('../test_helper');
 
-import {lock, createCustomEvent} from '../../src/utils';
+import {createCustomEvent} from '../../src/utils';
 
 const assert = require('power-assert');
-
-describe('lock', function () {
-  it('should ignore locked call and replay last call when free arg is called', function () {
-    var free = null;
-    var spy = this.sinon.spy();
-    var lockedFunc = lock(function (freeFunc, arg) {
-      spy(arg);
-      free = freeFunc;
-    });
-
-    lockedFunc(0);
-    assert(spy.calledOnce);
-    assert(spy.calledWith(0));
-
-    lockedFunc(1);
-    assert(spy.calledOnce);
-
-    lockedFunc(2);
-    free();
-    assert(spy.calledTwice);
-    assert(spy.secondCall.calledWith(2));
-  });
-
-  it('should not replay if there is no extra call', function () {
-    var free = null;
-    var spy = this.sinon.spy();
-    var lockedFunc = lock(function (freeFunc) {
-      spy();
-      free = freeFunc;
-    });
-
-    lockedFunc();
-    assert(spy.calledOnce);
-
-    free();
-    assert(spy.calledOnce);
-  });
-});
 
 describe('createCustomEvent', function () {
   it('should return a CustomEvent', function () {


### PR DESCRIPTION
The replacement is not as elegant, but I think it makes the logic more transparent.
For example, it makes the cause of #82 obvious.

It also reduces the min.gz size from 8,693 to 8,538 bytes, a 1.8% decrease.

---

For review once #80 has been merged. This is based on the branch from #80 to avoid merge conflicts once #80 is merged.