### PR TITLE
npm scripts: print gz size on build:dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/textcomplete.js",
   "scripts": {
     "build": "yarn run clean && run-p build:*",
-    "build:dist": "webpack && uglifyjs dist/textcomplete.js -o dist/textcomplete.min.js --source-map dist/textcomplete.min.js.map",
+    "build:dist": "webpack && uglifyjs dist/textcomplete.js -o dist/textcomplete.min.js --source-map dist/textcomplete.min.js.map && run-p print-dist-gz-size",
+    "print-dist-gz-size": "printf 'dist/textcomplete.min.js.gz: %d bytes\\n' \"$(gzip -9kc dist/textcomplete.min.js | wc --bytes)\"",
     "build:lib": "babel src -d lib -s",
     "clean": "rm -fr dist lib",
     "gh-release": "yarn pack textcomplete && gh-release -a textcomplete-$(cat package.json|jq -r .version).tgz",


### PR DESCRIPTION
This is what the output looks like:

```console
$ yarn build:dist
```

```console
yarn build:dist v0.24.5
$ webpack && uglifyjs dist/textcomplete.js -o dist/textcomplete.min.js --source-map dist/textcomplete.min.js.map && run-p print-dist-gz-size 
Hash: 64330eb06f694b8ab83b
Version: webpack 2.3.2
Time: 913ms
              Asset     Size  Chunks             Chunk Names
    textcomplete.js  74.7 kB       0  [emitted]  textcomplete
textcomplete.js.map  84.9 kB       0  [emitted]  textcomplete
   [0] ./src/search_result.js 1.95 kB {0} [built]
   [1] ./src/utils.js 4.98 kB {0} [built]
   [2] ./~/events/events.js 8.33 kB {0} [built]
   [3] ./src/editor.js 6.23 kB {0} [built]
   [4] ./src/strategy.js 4.46 kB {0} [built]
   [5] ./src/textarea.js 6.85 kB {0} [built]
   [6] ./src/textcomplete.js 8.66 kB {0} [built]
   [7] (webpack)/buildin/global.js 509 bytes {0} [built]
   [8] ./src/completer.js 4.23 kB {0} [built]
   [9] ./src/dropdown.js 13 kB {0} [built]
  [10] ./src/dropdown_item.js 5.08 kB {0} [built]
  [11] ./src/main.js 586 bytes {0} [built]
  [12] ./src/query.js 1.91 kB {0} [built]
  [13] ./~/textarea-caret/index.js 4.08 kB {0} [built]
yarn run v0.24.5
$ printf 'dist/textcomplete.min.js.gz: %d bytes\n' "$(gzip -9kc dist/textcomplete.min.js | wc --bytes)" 
dist/textcomplete.min.js.gz: 8693 bytes
Done in 0.10s.
Done in 1.81s.
```