### PR TITLE
Replace "events" with "eventemitter3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "webpack": "^2.3.2"
   },
   "dependencies": {
-    "events": "^1.1.0",
+    "eventemitter3": "^2.0.3",
     "textarea-caret": "^3.0.1"
   },
   "babel": {

--- a/src/completer.js
+++ b/src/completer.js
@@ -1,6 +1,6 @@
 // @flow
 
-import EventEmitter from 'events';
+import EventEmitter from 'eventemitter3';
 
 import Strategy from './strategy';
 import SearchResult from './search_result';

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -3,7 +3,7 @@
 import DropdownItem from './dropdown_item';
 import SearchResult from './search_result';
 import {createCustomEvent} from './utils';
-import EventEmitter from 'events';
+import EventEmitter from 'eventemitter3';
 
 const DEFAULT_CLASS_NAME = 'dropdown-menu textcomplete-dropdown';
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -3,7 +3,7 @@
 import {createCustomEvent} from './utils';
 import SearchResult from './search_result';
 
-import EventEmitter from 'events';
+import EventEmitter from 'eventemitter3';
 
 type KeyCode = 'ESC' | 'ENTER' | 'UP' | 'DOWN' | 'OTHER' | 'BS';
 

--- a/src/textcomplete.js
+++ b/src/textcomplete.js
@@ -6,7 +6,7 @@ import Dropdown from './dropdown';
 import Strategy, {type Properties} from './strategy';
 import SearchResult from './search_result';
 
-import EventEmitter from 'events';
+import EventEmitter from 'eventemitter3';
 
 const CALLBACK_METHODS = [
   'handleChange',

--- a/test/unit/editor_spec.js
+++ b/test/unit/editor_spec.js
@@ -2,7 +2,7 @@ require('../test_helper');
 
 import Editor from '../../src/editor';
 import {createSearchResult} from '../test_utils';
-import {EventEmitter} from 'events';
+import {EventEmitter} from 'eventemitter3';
 
 const assert = require('power-assert');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,7 +1893,11 @@ eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
 
-events@^1.0.0, events@^1.1.0:
+eventemitter3@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+
+events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 


### PR DESCRIPTION
See https://github.com/primus/eventemitter3

dist/textcomplete.min.js.gz:
 Before: 8427 bytes
  After: 8241 bytes
A 2.2% decrease