### PR TITLE
Add option for className of DropdownItem

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -6,6 +6,7 @@
     -   [destroy](#destroy)
     -   [registerStrategy](#registerstrategy)
     -   [run](#run)
+-   [DropdownItemOptions](#dropdownitemoptions)
 -   [DropdownItem](#dropdownitem)
     -   [destroy](#destroy-1)
     -   [appended](#appended)
@@ -75,9 +76,17 @@ Returns **this**
 
 **Parameters**
 
--   `text` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Head to input cursor.
+-   `text` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Head to input cursor.
 
 Returns **void** 
+
+## DropdownItemOptions
+
+Type: {className: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?}
+
+**Properties**
+
+-   `className` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
 
 ## DropdownItem
 
@@ -86,6 +95,7 @@ Encapsulate an item of dropdown.
 **Parameters**
 
 -   `searchResult` **[SearchResult](#searchresult)** 
+-   `options` **[DropdownItemOptions](#dropdownitemoptions)** 
 
 ### destroy
 
@@ -121,17 +131,18 @@ Returns **[DropdownItem](#dropdownitem)?**
 
 ## DropdownOptions
 
-Type: {className: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?, footer: function (any): ([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?, header: function (any): ([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?, maxCount: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?, placement: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?, rotate: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, style: {}?}
+Type: {className: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?, footer: function (any): ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?, header: function (any): ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?, maxCount: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?, placement: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?, rotate: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, style: {}?, item: [DropdownItemOptions](#dropdownitemoptions)?}
 
 **Properties**
 
--   `className` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
--   `footer` **function (any): ([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?** 
--   `header` **function (any): ([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?** 
--   `maxCount` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** 
--   `placement` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
--   `rotate` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** 
+-   `className` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+-   `footer` **function (any): ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?** 
+-   `header` **function (any): ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?** 
+-   `maxCount` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** 
+-   `placement` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+-   `rotate` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** 
 -   `style` **{}?** 
+-   `item` **[DropdownItemOptions](#dropdownitemoptions)?** 
 
 ## Dropdown
 
@@ -145,8 +156,8 @@ Encapsulate a dropdown view.
 
 **Properties**
 
--   `shown` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the #el is shown or not.
--   `items` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[DropdownItem](#dropdownitem)>** The array of rendered dropdown items.
+-   `shown` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the #el is shown or not.
+-   `items` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[DropdownItem](#dropdownitem)>** The array of rendered dropdown items.
 
 ### destroy
 
@@ -158,7 +169,7 @@ Render the given data as dropdown items.
 
 **Parameters**
 
--   `searchResults` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[SearchResult](#searchresult)>** 
+-   `searchResults` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[SearchResult](#searchresult)>** 
 -   `cursorOffset` **[CursorOffset](#cursoroffset)** 
 
 Returns **this** 
@@ -181,7 +192,7 @@ Returns **this**
 
 **Parameters**
 
--   `e` **[CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)** 
+-   `e` **[CustomEvent](https://developer.mozilla.org/docs/Web/API/CustomEvent/CustomEvent)** 
 
 Returns **this** 
 
@@ -189,7 +200,7 @@ Returns **this**
 
 **Parameters**
 
--   `e` **[CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)** 
+-   `e` **[CustomEvent](https://developer.mozilla.org/docs/Web/API/CustomEvent/CustomEvent)** 
 
 Returns **this** 
 
@@ -201,14 +212,14 @@ Returns **([DropdownItem](#dropdownitem) | null)**
 
 ## CursorOffset
 
-Type: {lineHeight: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), top: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), left: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?, right: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?}
+Type: {lineHeight: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), top: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), left: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?, right: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?}
 
 **Properties**
 
--   `lineHeight` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
--   `top` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
--   `left` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** 
--   `right` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** 
+-   `lineHeight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+-   `top` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+-   `left` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** 
+-   `right` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** 
 
 ## Editor
 
@@ -250,7 +261,7 @@ Returns **[CursorOffset](#cursoroffset)**
 Editor string value from head to cursor.
 Returns null if selection type is range not cursor.
 
-Returns **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
 
 ### emitMoveEvent
 
@@ -263,7 +274,7 @@ Child class must call this method at proper timing with proper parameter.
 
 -   `code` **(`"UP"` \| `"DOWN"`)** 
 
-Returns **[CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)** 
+Returns **[CustomEvent](https://developer.mozilla.org/docs/Web/API/CustomEvent/CustomEvent)** 
 
 ### emitEnterEvent
 
@@ -272,7 +283,7 @@ Returns **[CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomE
 Emit a enter event, which selects current search result.
 Child class must call this method at proper timing.
 
-Returns **[CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)** 
+Returns **[CustomEvent](https://developer.mozilla.org/docs/Web/API/CustomEvent/CustomEvent)** 
 
 ### emitChangeEvent
 
@@ -281,7 +292,7 @@ Returns **[CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomE
 Emit a change event, which triggers auto completion.
 Child class must call this method at proper timing.
 
-Returns **[CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)** 
+Returns **[CustomEvent](https://developer.mozilla.org/docs/Web/API/CustomEvent/CustomEvent)** 
 
 ### emitEscEvent
 
@@ -290,7 +301,7 @@ Returns **[CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomE
 Emit a esc event, which hides dropdown element.
 Child class must call this method at proper timing.
 
-Returns **[CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)** 
+Returns **[CustomEvent](https://developer.mozilla.org/docs/Web/API/CustomEvent/CustomEvent)** 
 
 ### getCode
 
@@ -300,7 +311,7 @@ Helper method for parsing KeyboardEvent.
 
 **Parameters**
 
--   `e` **[KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent)** 
+-   `e` **[KeyboardEvent](https://developer.mozilla.org/docs/Web/API/KeyboardEvent)** 
 
 Returns **KeyCode** 
 
@@ -311,7 +322,7 @@ Encapsulate matching condition between a Strategy and current editor's value.
 **Parameters**
 
 -   `strategy` **[Strategy](#strategy)** 
--   `term` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `term` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 -   `match` **MatchData** 
 
 ### execute
@@ -320,7 +331,7 @@ Invoke search strategy and callback the given function.
 
 **Parameters**
 
--   `callback` **function ([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[SearchResult](#searchresult)>): void** 
+-   `callback` **function ([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[SearchResult](#searchresult)>): void** 
 
 ## SearchResult
 
@@ -328,26 +339,26 @@ Encapsulate an result of each search results.
 
 **Parameters**
 
--   `data` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `term` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `term` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 -   `strategy` **[Strategy](#strategy)** 
 
 ## StrategyProperties
 
 Properties for a strategy.
 
-Type: {match: ([RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) | function ([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)): (MatchData | null)), search: [Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function), replace: function (any): ([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)> | [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) | null), cache: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, context: [Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)?, template: function (any): [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?, index: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?, id: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?}
+Type: {match: ([RegExp](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp) | function ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)): (MatchData | null)), search: [Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function), replace: function (any): ([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)> | [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | null), cache: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, context: [Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)?, template: function (any): [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?, index: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?, id: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?}
 
 **Properties**
 
--   `match` **([RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) | function ([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)): (MatchData | null))** 
--   `search` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** 
--   `replace` **function (any): ([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)> | [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) | null)** 
--   `cache` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** 
--   `context` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)?** 
--   `template` **function (any): [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
--   `index` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** 
--   `id` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+-   `match` **([RegExp](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp) | function ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)): (MatchData | null))** 
+-   `search` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** 
+-   `replace` **function (any): ([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)> | [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | null)** 
+-   `cache` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** 
+-   `context` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)?** 
+-   `template` **function (any): [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+-   `index` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** 
+-   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
 
 ## Strategy
 
@@ -367,7 +378,7 @@ Build a Query object by the given string if this matches to the string.
 
 **Parameters**
 
--   `text` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Head to input cursor.
+-   `text` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Head to input cursor.
 
 Returns **[Query](#query)?** 
 
@@ -375,7 +386,7 @@ Returns **[Query](#query)?**
 
 **Parameters**
 
--   `data` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** An element of array callbacked by search function.
+-   `data` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** An element of array callbacked by search function.
 
 ## Textarea
 
@@ -385,7 +396,7 @@ Encapsulate the target textarea element.
 
 **Parameters**
 
--   `el` **[HTMLTextAreaElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement)** 
+-   `el` **[HTMLTextAreaElement](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement)** 
 
 ### destroy
 
@@ -430,7 +441,7 @@ The core of textcomplete. It acts as a mediator.
 
 **Parameters**
 
--   `destroyEditor` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**  (optional, default `true`)
+-   `destroyEditor` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**  (optional, default `true`)
 
 Returns **this** 
 
@@ -438,7 +449,7 @@ Returns **this**
 
 **Parameters**
 
--   `strategyPropsArray` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[StrategyProperties](#strategyproperties)>** 
+-   `strategyPropsArray` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[StrategyProperties](#strategyproperties)>** 
 
 **Examples**
 
@@ -464,6 +475,6 @@ Start autocompleting.
 
 **Parameters**
 
--   `text` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Head to input cursor.
+-   `text` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Head to input cursor.
 
 Returns **this** 

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -1,7 +1,7 @@
 // @flow
 import EventEmitter from "eventemitter3"
 
-import DropdownItem from "./dropdown_item"
+import DropdownItem, { type DropdownItemOptions } from "./dropdown_item"
 import SearchResult from "./search_result"
 import { createCustomEvent } from "./utils"
 import type { CursorOffset } from "./editor"
@@ -17,6 +17,7 @@ export type DropdownOptions = {
   placement?: string,
   rotate?: boolean,
   style?: { [string]: string },
+  item?: DropdownItemOptions,
 }
 
 /**
@@ -34,6 +35,7 @@ export default class Dropdown extends EventEmitter {
   maxCount: $PropertyType<DropdownOptions, "maxCount">
   rotate: $PropertyType<DropdownOptions, "rotate">
   placement: $PropertyType<DropdownOptions, "placement">
+  itemOptions: DropdownItemOptions
   _el: ?HTMLUListElement
 
   static createElement(): HTMLUListElement {
@@ -60,6 +62,7 @@ export default class Dropdown extends EventEmitter {
     this.el.className = options.className || DEFAULT_CLASS_NAME
     this.rotate = options.hasOwnProperty("rotate") ? options.rotate : true
     this.placement = options.placement
+    this.itemOptions = options.item || {}
     const style = options.style
     if (style) {
       Object.keys(style).forEach(key => {
@@ -101,7 +104,7 @@ export default class Dropdown extends EventEmitter {
     const rawResults = searchResults.map(searchResult => searchResult.data)
     const dropdownItems = searchResults
       .slice(0, this.maxCount || searchResults.length)
-      .map(searchResult => new DropdownItem(searchResult))
+      .map(searchResult => new DropdownItem(searchResult, this.itemOptions))
     this.clear()
       .setStrategyId(searchResults[0])
       .renderEdge(rawResults, "header")

--- a/src/dropdown_item.js
+++ b/src/dropdown_item.js
@@ -3,9 +3,13 @@
 import Dropdown from "./dropdown"
 import SearchResult from "./search_result"
 
-export const CLASS_NAME = "textcomplete-item"
-const ACTIVE_CLASS_NAME = `${CLASS_NAME} active`
+export const DEFAULT_CLASS_NAME = "textcomplete-item"
 const CALLBACK_METHODS = ["onClick", "onMouseover"]
+
+/** @typedef */
+export type DropdownItemOptions = {
+  className?: string,
+}
 
 /**
  * Encapsulate an item of dropdown.
@@ -13,14 +17,18 @@ const CALLBACK_METHODS = ["onClick", "onMouseover"]
 export default class DropdownItem {
   searchResult: SearchResult
   active: boolean
+  className: string
+  activeClassName: string
   siblings: DropdownItem[]
   dropdown: Dropdown
   index: number
   _el: ?HTMLLIElement
 
-  constructor(searchResult: SearchResult) {
+  constructor(searchResult: SearchResult, options: DropdownItemOptions) {
     this.searchResult = searchResult
     this.active = false
+    this.className = options.className || DEFAULT_CLASS_NAME;
+    this.activeClassName = `${this.className} active`;
 
     CALLBACK_METHODS.forEach(method => {
       ;(this: any)[method] = (this: any)[method].bind(this)
@@ -32,7 +40,7 @@ export default class DropdownItem {
       return this._el
     }
     const li = document.createElement("li")
-    li.className = this.active ? ACTIVE_CLASS_NAME : CLASS_NAME
+    li.className = this.active ? this.activeClassName : this.className
     const a = document.createElement("a")
     a.innerHTML = this.searchResult.render()
     li.appendChild(a)
@@ -81,7 +89,7 @@ export default class DropdownItem {
       }
       this.dropdown.activeItem = this
       this.active = true
-      this.el.className = ACTIVE_CLASS_NAME
+      this.el.className = this.activeClassName
     }
     return this
   }
@@ -122,7 +130,7 @@ export default class DropdownItem {
   deactivate() {
     if (this.active) {
       this.active = false
-      this.el.className = CLASS_NAME
+      this.el.className = this.className
       this.dropdown.activeItem = null
     }
     return this

--- a/test/integration/dropdown_item_option_spec.js
+++ b/test/integration/dropdown_item_option_spec.js
@@ -1,0 +1,58 @@
+require("../test_helper")
+
+import Textcomplete from "../../src/textcomplete"
+import Textarea from "../../src/textarea"
+
+import { Keyboard } from "keysim"
+
+const assert = require("power-assert")
+const keyboard = Keyboard.US_ENGLISH
+
+describe("Dropdown item options integration test", function() {
+  var textareaEl, textarea
+
+  beforeEach(function() {
+    textareaEl = document.createElement("textarea")
+    document.body.appendChild(textareaEl)
+    textarea = new Textarea(textareaEl)
+  })
+
+  afterEach(function() {
+    textarea.destroy()
+    document.body.removeChild(textareaEl)
+  })
+
+  function setup(option, strategy) {
+    var textcomplete = new Textcomplete(textarea, { dropdown: { item: option } })
+    textcomplete.register([strategy])
+    return textcomplete
+  }
+
+  describe("className", function() {
+    it("should be set as class attribute of dropdown item element", function() {
+      var className = "hello-world-item"
+      setup(
+        { className },
+        {
+          usernames: ["alice"],
+          match: /(^|\s)@(\w+)$/,
+          search: function(term, callback) {
+            callback(
+              this.usernames.filter(username => username.startsWith(term)),
+            )
+          },
+          replace: function(username) {
+            return `$1@${username} `
+          },
+        },
+      )
+
+      textareaEl.value = "@a"
+      textareaEl.selectionStart = textareaEl.selectionEnd = 2
+      keyboard.dispatchEventsForInput("@a", textareaEl)
+
+      var dropdownItemEl = document.getElementsByClassName(className)
+      assert.equal(dropdownItemEl.length, 1)
+    })
+  })
+})

--- a/test/integration/dropdown_option_spec.js
+++ b/test/integration/dropdown_option_spec.js
@@ -2,7 +2,7 @@ require("../test_helper")
 
 import Textcomplete from "../../src/textcomplete"
 import Textarea from "../../src/textarea"
-import { CLASS_NAME } from "../../src/dropdown_item"
+import { DEFAULT_CLASS_NAME } from "../../src/dropdown_item"
 
 import { Keyboard } from "keysim"
 
@@ -106,7 +106,7 @@ describe("Dropdown options integration test", function() {
       textareaEl.selectionStart = textareaEl.selectionEnd = 2
       keyboard.dispatchEventsForInput("@a", textareaEl)
 
-      var items = document.getElementsByClassName(CLASS_NAME)
+      var items = document.getElementsByClassName(DEFAULT_CLASS_NAME)
       assert.equal(items.length, maxCount)
     })
   })

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -73,8 +73,9 @@ export function createQuery(
 export function createDropdownItem(
   dropdown = new Dropdown(),
   searchResult = createSearchResult(),
+  options = {}
 ) {
-  var dropdownItem = new DropdownItem(searchResult)
+  var dropdownItem = new DropdownItem(searchResult, options)
   dropdown.append([dropdownItem])
   return dropdownItem
 }

--- a/test/unit/dropdown_spec.js
+++ b/test/unit/dropdown_spec.js
@@ -283,7 +283,7 @@ describe("Dropdown", function() {
     })
 
     it("should empty itself", function() {
-      dropdown.append([new DropdownItem(createSearchResult())])
+      dropdown.append([new DropdownItem(createSearchResult(), {})])
       assert.equal(dropdown.items.length, 1)
       subject()
       assert.equal(dropdown.items.length, 0)
@@ -324,7 +324,7 @@ describe("Dropdown", function() {
   describe("#append", function() {
     it("should call #appended of the appended dropdown item", function() {
       var dropdown = new Dropdown({})
-      var dropdownItem = new DropdownItem(createSearchResult())
+      var dropdownItem = new DropdownItem(createSearchResult(), {})
       var stub = this.sinon.stub(dropdownItem, "appended")
       dropdown.append([dropdownItem])
       assert(stub.calledOnce)
@@ -341,7 +341,7 @@ describe("Dropdown", function() {
 
     beforeEach(function() {
       dropdown = new Dropdown({})
-      dropdownItem = new DropdownItem(createSearchResult())
+      dropdownItem = new DropdownItem(createSearchResult(), {})
       dropdown.append([dropdownItem])
     })
 


### PR DESCRIPTION
There's an option to specify the `className` of the Dropdown itself, so it would be nice (and make sense) to be able to specify it for the DropdownItems as well. This PR adds such functionality. I'll update the documentation after creating the PR and commit it to the same branch.

I successfully ran the unit test, although it seemed to start a Karma server and hang indefinitely. I didn't get any warnings about test failures beforehand, so I can only assume the tests passed.