### PR TITLE
Export `Textarea` and `Textcomplete` from main entry file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- Export `Textarea` and `Textcomplete` from main entry file.
 
 ## [0.15.0] - 2017-12-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ npm install --save textcomplete
 Then you can load the module into your code with `require` call:
 
 ```js
-var Textcomplete = require('textcomplete/lib/textcomplete');
-var Textarea = require('textcomplete/lib/textarea');
+var { Textcomplete, Textarea } = require('textcomplete');
 ```
 
 The `Textarea` object is a kind of *editor class*. An editor encapsulates an HTML element where users input text. The `Textarea` editor is an editor for textarea element.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "textcomplete",
   "version": "0.15.0",
   "description": "Autocomplete for textarea elements",
-  "main": "lib/textcomplete.js",
+  "main": "lib/index.js",
   "scripts": {
     "build": "yarn run clean && run-p build:*",
     "build:dist": "webpack && webpack --env=min && run-p print-dist-gz-size",

--- a/src/doc/main.js
+++ b/src/doc/main.js
@@ -1,7 +1,6 @@
 require('./main.css');
 
-import Textcomplete from '../textcomplete';
-import Textarea from '../textarea';
+import { Textarea, Textcomplete } from '../index';
 import hljs from 'highlight.js';
 
 global.Textarea = Textarea;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+// @flow
+
+import Textarea from "./textarea"
+import Textcomplete from "./textcomplete"
+
+export { Textarea, Textcomplete }


### PR DESCRIPTION
Now you can import `Textarea` and `Textcomplete` from "textcomplete" 

## Before

```js
var Textarea = require("textcomplete/lib/textarea")
var Textcomplete = require("textcomplete/lib/textcomplete")
```

## After

```js
import { Textarea, Textcomplete } from "textcomplete"
```

```js
var { Textarea, Textcomplete } = require("textcomplete")
```