### PR TITLE
Manually deactivate dropdown with new hide() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- Add hide method to textcomplete to deactivate dropdown manually
 
 ## [0.16.1] - 2018-02-28
 ### Fixed

--- a/doc/api.md
+++ b/doc/api.md
@@ -49,6 +49,7 @@
 -   [TextcompleteOptions](#textcompleteoptions)
 -   [Textcomplete](#textcomplete)
     -   [destroy](#destroy-6)
+    -   [hide](#hide)
     -   [register](#register)
     -   [trigger](#trigger)
 
@@ -443,6 +444,10 @@ The core of textcomplete. It acts as a mediator.
 **Parameters**
 
 -   `destroyEditor` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**  (optional, default `true`)
+
+Returns **this** 
+
+### hide
 
 Returns **this** 
 

--- a/src/textcomplete.js
+++ b/src/textcomplete.js
@@ -68,6 +68,14 @@ export default class Textcomplete extends EventEmitter {
 
   /**
    * @return {this}
+   */
+  hide() {
+    this.dropdown.deactivate()
+    return this
+  }
+
+  /**
+   * @return {this}
    * @example
    * textcomplete.register([{
    *   match: /(^|\s)(\w+)$/,

--- a/test/unit/textcomplete_spec.js
+++ b/test/unit/textcomplete_spec.js
@@ -46,6 +46,23 @@ describe("Textcomplete", function() {
     })
   })
 
+  describe("#hide", function() {
+    function subject() {
+      return textcomplete.hide()
+    }
+
+    it("should return itself", function() {
+      assert.strictEqual(subject(), textcomplete)
+    })
+
+    it("should deactivate dropdown", function() {
+      var stub = this.sinon.stub(textcomplete.dropdown, "deactivate")
+
+      subject()
+      assert(stub.calledOnce)
+    })
+  })
+
   describe("#register", function() {
     var props
 


### PR DESCRIPTION
In https://github.com/thelounge/thelounge/issues/2209 we ran into a case where we want to deactivate the dropdown manually with an event external to textcomplete. This change adds a public `hide()` method to do just that.