### PR TITLE
Check element exists before sending it an event

### DIFF
--- a/src/textarea.js
+++ b/src/textarea.js
@@ -51,7 +51,8 @@ export default class Textarea extends Editor {
       this.el.focus() // Clicking a dropdown item removes focus from the element.
       if (Array.isArray(replace)) {
         update(this.el, replace[0], replace[1])
-        this.el.dispatchEvent(new Event("input"))
+        if (this.el)
+          this.el.dispatchEvent(new Event("input"))
       }
     }
   }


### PR DESCRIPTION
I'm using this from React and it seems React replaces the element. It was working fine from a users point of view but in the console I'm seeing lots of:

```
Uncaught TypeError: Cannot read property 'dispatchEvent' of null
    at Textarea.applySearchResult (textarea.js:90)
    at Textcomplete.handleSelect (textcomplete.js:223)
    at Dropdown.emit (index.js:129)
    at Dropdown.select (dropdown.js:157)
    at Textcomplete.handleEnter (textcomplete.js:186)
    at Textarea.emit (index.js:129)
    at Textarea.emitEnterEvent (editor.js:126)
    at Textarea.onKeydown (textarea.js:174)
```